### PR TITLE
move git config into module

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -24,6 +24,7 @@ in {
     # imports
     ./modules/alacritty.nix
     ./modules/firefox.nix
+    ./modules/git.nix
     ./modules/zsh.nix
   ];
 

--- a/home.nix
+++ b/home.nix
@@ -48,14 +48,6 @@ in {
     youtube-dl
   ];
 
-  programs = {
-    git = {
-      enable = true;
-      userEmail = "git@chris-ge.de";
-      userName = "nonchris";
-    };
-  };
-
   # This value determines the Home Manager release that your
   # configuration is compatible with. This helps avoid breakage
   # when a new Home Manager release introduces backwards

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -1,0 +1,14 @@
+{ config, pkgs, lib, ... }: {
+  programs = {
+    git = {
+      enable = true;
+
+      ignores = [ "tags" "*.swp" ];
+
+      extraConfig = { pull.rebase = false; };
+
+      userEmail = "git@chris-ge.de";
+      userName = "nonchris";
+    };
+  };
+}


### PR DESCRIPTION
Your git config will get referenced through different systems.
It makes sense to move it into a separate module.