### PR TITLE
remove seperate allowUnfree file

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -1,1 +1,0 @@
-{ allowUnfree = true; }

--- a/home.nix
+++ b/home.nix
@@ -15,6 +15,9 @@ in {
   home.username = "chris";
   home.homeDirectory = "/home/chris";
 
+  # Allow "unfree" licenced packages
+  nixpkgs.config = { allowUnfree = true; };
+
   # Imports
   imports = [
     # imports from MayNiklas


### PR DESCRIPTION
We don't need a separate config.nix file for the allowUnfree parameter.
It makes sense to include it in home.nix.